### PR TITLE
feat: Condense display of search results.

### DIFF
--- a/app/Views/templates/search-result.php
+++ b/app/Views/templates/search-result.php
@@ -1,9 +1,9 @@
-<div class="container mx-auto max-w-xl mb-12">
+<div class="container mx-auto max-w-xl mb-8">
     
     <!-- Title -->
     <h2 class="text-darkCyan text-xl leading-tight mb-1">
         <?php if ( $document->urlMain ) {
-            printf( '<a class="" href="%1$s" rel="bookmark">%2$s</a>',
+            printf( '<a href="%1$s" rel="bookmark">%2$s</a>',
                 esc( $document->urlMain ),
                 $title
         );
@@ -14,20 +14,20 @@
     </h2>
 
     <!-- Author -->
-    <p class="text-slate text-lg">
+    <span class="text-slate">
     <?php if (!empty($document->creator[0])) {
         foreach ($creators as $creator) {
             echo $creator;
         }
     } ?>
-    </p>
+    </span>
 
 
     <!-- Publication Information -->
-    <p class="text-slate text-opacity-75">
+    <span class="text-slate text-opacity-75">
 
     <?php 
-    // Publisher(s), followed by comma
+    // Publisher(s)
     if (!empty($document->publisher[0])) {
         foreach ($publishers as $publisher) {
             echo($publisher); 
@@ -35,7 +35,7 @@
         }
     }
 
-    // Place of publication, followed by comma
+    // Place of publication
     if (!empty($document->placeOfPublication[0])) { 
         foreach ($placesOfPublication as $placeOfPublication) {
             echo($placeOfPublication);
@@ -43,29 +43,15 @@
         }
     }
 
-    // Year of publication, followed by full stop.
+    // Year of publication
     if (!empty($document->year)) {
         echo(esc($document->year));
-        echo('.');
     }
     ?>
-    </p>
-
-    <!-- Extra noise that may not provide user value. -->
-    <div class="hidden">
-        <span class="badge badge-primary">Source: <?= esc($document->organisation); ?></span>
-        <span class="badge badge-dark">Language: <?= esc($document->language); ?></span>
-        <?php if (!empty($document->licence)) {?>
-            <a href='<?= esc($document->licence); ?>' class="badge badge-success">Licence: <?= esc($document->licence); ?></a><br />
-        <?php } ?>
-        <?php if (!empty($document->catLink)) {?>
-            <a href='<?= esc($document->catLink); ?>' class="badge badge-info">Link: Original catalogue record (ID: <?= esc($document->idLocal); ?>)</a><br />
-        <?php } ?>
-    </div>
-
+    </span>
     
     <!-- Icons for different formats -->
-    <div class="flex space-x-1 mt-1">
+    <div class="inline-flex space-x-1">
         <?php if (!empty($document->urlPDF)) {?>
             <a href='<?= esc($document->urlPDF); ?>'><img src="/images/pdf.png" height="16" width="16" /></a>
         <?php } ?>


### PR DESCRIPTION
A wee tweak I think makes the search results a bit easier to use & read—I was trying to break things up for legibility, but it wound up making things harder to scan, without really helping improve legibility at all. Condensing things a bit actually works better with the content that we have available here.

**Before:**
<img width="802" alt="Screenshot 2020-08-01 at 19 38 49" src="https://user-images.githubusercontent.com/376315/89108260-c06a5680-d42e-11ea-8c78-4febb92eb27c.png">

**After:**
<img width="802" alt="Screenshot 2020-08-01 at 19 39 18" src="https://user-images.githubusercontent.com/376315/89108265-c4967400-d42e-11ea-91ee-66dfe79117ee.png">

The placement of the icons isn't exactly right (and the colours might be too distracting!) but we can improve this iteratively.

@stuartlewis as I have small fixes for things like this, I'm just going to make PRs and have you review them, but do let me know if you'd prefer another approach here! 🙂