### PR TITLE
feat: Improve search form

### DIFF
--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -4,7 +4,7 @@
     <div class="w-full bg-white max-w-2xl rounded-full flex">
         <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 px-2 my-2 ml-6 mr-12 text-lg text-gray-700 border-2 border-transparent focus:border-blue-300 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
 
-        <button class="w-auto items-center text-blue-800 -ml-12 p-2 pr-4 hover:text-blue-500">
+        <button class="w-auto items-center text-blue-800 -ml-12 py-2 px-3 mr-2 my-2 rounded-full border-2 border-transparent hover:text-blue-500 focus:outline-none focus:border-blue-300">
             <span><?php echo file_get_contents('svg/search.svg'); ?></span>
             <span class="sr-only">Search</span>
         </button>

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -1,8 +1,8 @@
 <form method="get" action="/search" class="container flex flex-col justify-center items-center">
     <label class="block w-full max-w-2xl text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
 
-    <div class="w-full bg-white max-w-2xl rounded-full flex" onfocusin="this.classList.add('focused')" onfocusout="this.classList.remove('focused')">
-        <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 px-2 my-2 ml-6 mr-12 text-lg text-gray-700 border-2 border-transparent focus:border-blue-300 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
+    <div class="w-full bg-white max-w-2xl rounded-full flex border-2 border-transparent" onfocusin="this.classList.add('search-focused')" onfocusout="this.classList.remove('search-focused')">
+        <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 px-2 my-2 ml-6 mr-12 text-lg text-gray-700 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
 
         <button class="w-auto items-center text-blue-800 -ml-12 py-2 px-3 mr-2 my-2 rounded-full border-2 border-transparent hover:text-blue-500 focus:outline-none focus:border-blue-300">
             <span><?php echo file_get_contents('svg/search.svg'); ?></span>

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -1,4 +1,12 @@
 <form method="get" action="/search" class="container flex flex-col justify-center items-center">
     <label class="block w-full max-w-2xl text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
-    <input type="search" name="q" id="search-input" class="w-full max-w-2xl rounded-full py-4 px-6 text-lg text-gray-700 focus:outline-none focus:border-b-2 focus:border-blue-500" value="<?php echo isset($q) ? esc($q) : "" ?>" />
+
+    <div class="w-full bg-white max-w-2xl rounded-full flex focus:border-blue-500">
+        <input type="search" name="q" id="search-input" class="w-full max-w-2xl rounded-full py-4 px-6 text-lg text-gray-700 focus:outline-none border-2 focus:border-blue-500 focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
+
+        <button class="w-auto items-center text-blue-800 -ml-12 p-2 pr-4 hover:text-blue-500">
+            <span><?php echo file_get_contents('svg/search.svg'); ?></span>
+            <span class="sr-only">Search</span>
+        </button>
+    </div>
 </form>

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -1,7 +1,7 @@
 <form method="get" action="/search" class="container flex flex-col justify-center items-center">
     <label class="block w-full max-w-2xl text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
 
-    <div class="w-full bg-white max-w-2xl rounded-full flex">
+    <div class="w-full bg-white max-w-2xl rounded-full flex" onfocusin="this.classList.add('focused')" onfocusout="this.classList.remove('focused')">
         <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 px-2 my-2 ml-6 mr-12 text-lg text-gray-700 border-2 border-transparent focus:border-blue-300 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
 
         <button class="w-auto items-center text-blue-800 -ml-12 py-2 px-3 mr-2 my-2 rounded-full border-2 border-transparent hover:text-blue-500 focus:outline-none focus:border-blue-300">

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -2,7 +2,7 @@
     <label class="block w-full max-w-2xl text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
 
     <div class="w-full bg-white max-w-2xl rounded-full flex focus:border-blue-500">
-        <input type="search" name="q" id="search-input" class="w-full max-w-2xl rounded-full py-4 px-6 text-lg text-gray-700 focus:outline-none border-2 focus:border-blue-500 focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
+        <input type="search" name="q" id="search-input" class="w-full max-w-2xl rounded-full py-4 px-6 text-lg text-gray-700 focus:outline-none border-2 border-transparent focus:border-blue-500 focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
 
         <button class="w-auto items-center text-blue-800 -ml-12 p-2 pr-4 hover:text-blue-500">
             <span><?php echo file_get_contents('svg/search.svg'); ?></span>

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -1,8 +1,8 @@
 <form method="get" action="/search" class="container flex flex-col justify-center items-center">
     <label class="block w-full max-w-2xl text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
 
-    <div class="w-full bg-white max-w-2xl rounded-full flex focus:border-blue-500">
-        <input type="search" name="q" id="search-input" class="w-full max-w-2xl rounded-full py-4 px-6 text-lg text-gray-700 focus:outline-none border-2 border-transparent focus:border-blue-500 focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
+    <div class="w-full bg-white max-w-2xl rounded-full flex">
+        <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 px-2 my-2 ml-6 mr-12 text-lg text-gray-700 border-2 border-transparent focus:border-blue-300 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />
 
         <button class="w-auto items-center text-blue-800 -ml-12 p-2 pr-4 hover:text-blue-500">
             <span><?php echo file_get_contents('svg/search.svg'); ?></span>

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -41,4 +41,8 @@ p {
     @apply py-3 px-10 rounded-md bg-blue-800 text-gray-100;
 }
 
+.search-focused {
+    @apply border-2 border-blue-300 !important;
+}
+
 @tailwind utilities;

--- a/public/svg/search.svg
+++ b/public/svg/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>


### PR DESCRIPTION
This adds a proper search button to the search input field, making the component more usable and accessible.

Before:
<img width="802" alt="Screenshot 2020-08-24 at 13 05 22" src="https://user-images.githubusercontent.com/376315/91042915-7b3edc00-e60a-11ea-959b-0700497efa97.png">

After:
<img width="802" alt="Screenshot 2020-08-24 at 13 05 00" src="https://user-images.githubusercontent.com/376315/91042883-6cf0c000-e60a-11ea-9cf3-033daeae4aa4.png">

Changing the padding around the search field allows us to better support built-in browser functionality, like the "x" clear input button in webkit-based browsers, at the expense of a small aesthetic cost (the focus styling isn't as elegant.)

Here's what the focus styling currently looks like:

<img width="802" alt="Screenshot 2020-08-24 at 13 06 20" src="https://user-images.githubusercontent.com/376315/91042984-9d385e80-e60a-11ea-9d9d-2cd2571d03ae.png">

This isn't _ideal_ in terms of aesthetics, but it's the best I could do here without resorting to a Javascript-based solution. If we could extend the focus border to the containing `div`, this would definitely be a better solution in terms of aesthetics, without compromising either the accessibility or usability of the component. 

@brizee how difficult would it be from within our current setup to add a class to the containing div when focus moves to the search input? I'm suspecting "not very", but I know you're doing a lot of JS work and don't want to step on any toes. If it's easy to change around, I'd recommend that we do that, but I actually don't hate this solution as-is. We can certainly merge this as-is for now, and I can file the additional change as a nice-to-have enhancement for the future. 🙂

Close #50 & close #64.
