### PR TITLE
feat: Style Doorbell form

### DIFF
--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -168,7 +168,22 @@ body #doorbell form {
 }
 
 body #doorbell-container .close {
-    @apply right-0 top-0 mt-2 mr-3 text-2xl text-gray-500 opacity-100 font-medium;
+    @apply right-0 top-0 mt-3 mr-2 text-2xl text-gray-500 opacity-100 font-medium border-solid border-2 border-transparent rounded-full py-1 px-2 leading-4;
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+}
+
+#doorbell-close span {
+  vertical-align: 0.25rem;
+}
+
+
+body #doorbell-container .close:hover {
+    @apply text-blue-700;
+}
+
+body #doorbell-container .close:focus {
+    @apply outline-none border-blue-400 text-blue-700;
 }
 
 body #doorbell form legend {

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -217,7 +217,7 @@ body #doorbell form textarea {
 }
 
 body #doorbell #doorbell-powered-by {
-    @apply block text-xs text-gray-500 text-center mt-8;
+    @apply block text-xs text-gray-600 text-center mt-8;
 }
 
 @tailwind utilities;

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -56,16 +56,19 @@ p {
 }
 
 /* Buttons */
-.button-primary {
+.button-primary,
+body #doorbell-button {
     @apply py-3 px-10 rounded-md bg-blue-800 text-gray-100 border-2 border-transparent;
     transition: all 200ms ease-in-out;
 }
 
-.button-primary:hover {
+.button-primary:hover,
+body #doorbell-button:hover {
     @apply bg-red-700;
 }
 
-.button-primary:focus {
+.button-primary:focus,
+body #doorbell-button:hover {
     @apply border-blue-400;
 }
 
@@ -127,4 +130,10 @@ p {
 .skeleton>h2{
     margin-top:0;
 }
+
+/* Style the Doorbell button + form */
+body #doorbell-button {
+    @apply rounded-b-none;
+}
+
 @tailwind utilities;

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -212,7 +212,9 @@ body #doorbell form textarea {
 }
 
 #doorbell-feedback:focus,
-#doorbell-email:focus {
+#doorbell-email:focus,
+body #doorbell form textarea:focus, 
+body #doorbell form input[type="email"]:focus {
     @apply outline-none text-blue-700 border-blue-400;
 }
 

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -57,18 +57,21 @@ p {
 
 /* Buttons */
 .button-primary,
-body #doorbell-button {
+body #doorbell-button,
+#doorbell .buttons button {
     @apply py-3 px-10 rounded-md bg-blue-800 text-gray-100 border-2 border-transparent;
     transition: all 200ms ease-in-out;
 }
 
 .button-primary:hover,
-body #doorbell-button:hover {
+body #doorbell-button:hover,
+#doorbell .buttons button:hover {
     @apply bg-red-700;
 }
 
 .button-primary:focus,
-body #doorbell-button:hover {
+body #doorbell-button:focus,
+#doorbell .buttons button:focus {
     @apply border-blue-400;
 }
 
@@ -134,6 +137,72 @@ body #doorbell-button:hover {
 /* Style the Doorbell button + form */
 body #doorbell-button {
     @apply rounded-b-none;
+}
+
+body #doorbell-background {
+    @apply bg-gray-900;
+}
+
+@media screen and (max-width: 640px) {
+    body #doorbell {
+        @apply left-0 ml-2;
+        width: calc(100% - 1rem);
+    }
+}
+
+@media screen and (min-width: 641px) {
+    body #doorbell {
+        width: 600px;
+        margin-left: -300px;
+    }
+}
+
+body #doorbell form {
+    @apply rounded-lg bg-white shadow-lg pt-6 px-4 pb-4;
+}
+
+@media screen and (min-width: 640px) {
+    body #doorbell form {
+        @apply pt-8 px-10 pb-6;
+    }
+}
+
+body #doorbell-container .close {
+    @apply right-0 top-0 mt-2 mr-3 text-2xl text-gray-500 opacity-100 font-medium;
+}
+
+body #doorbell form legend {
+    @apply hidden;
+}
+
+#doorbell-feedback-label,
+#doorbell-email-label {
+    @apply block w-full max-w-2xl mb-1 text-sm text-gray-800;
+}
+
+#doorbell-feedback,
+#doorbell-email,
+body #doorbell form textarea, 
+body #doorbell form input[type="email"] {
+    @apply block bg-white rounded-md border-2 border-gray-300 p-3 mb-6 text-base text-gray-700 box-border w-full;
+}
+
+body #doorbell form textarea::placeholder, 
+body #doorbell form input[type="email"]::placeholder {
+    color: transparent;
+}
+
+body #doorbell form textarea {
+    @apply h-40;
+}
+
+#doorbell-feedback:focus,
+#doorbell-email:focus {
+    @apply outline-none text-blue-700 border-blue-400;
+}
+
+body #doorbell #doorbell-powered-by {
+    @apply block text-xs text-gray-500 text-center mt-8;
 }
 
 @tailwind utilities;


### PR DESCRIPTION
This PR styles the Doorbell form as best as we can, given limited control over the markup.

Before:
<img width="642" alt="Screenshot 2020-09-06 at 01 19 22" src="https://user-images.githubusercontent.com/376315/92315565-34c08880-efdf-11ea-9d74-98cea7023b63.png">

After:
<img width="642" alt="Screenshot 2020-09-06 at 01 18 53" src="https://user-images.githubusercontent.com/376315/92315563-338f5b80-efdf-11ea-978e-1915e1b49d0f.png">

The Doorbell form doesn't actually display for me locally, so I had to sort of hack things about to test things. I think it should all work as expected, but we'll want to confirm once it's up on the staging site. The CSS selectors used here aren't ideal, but they're the best workaround to overwrite Doorbell's built-in styling, so 🤷‍♀️.

