### PR TITLE
feat: Nix file type icons for plain text.

### DIFF
--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -41,7 +41,7 @@
     <div class="container mx-auto max-w-xl mb-8">
 
         <!-- Title -->
-        <h2 class="text-darkCyan text-xl leading-tight mb-1">
+        <h2 class="text-darkCyan text-xl leading-tight mb-2">
             <a class="text-blue-700 hover:text-blue-600" rel="bookmark"></a>
         </h2>
 
@@ -56,13 +56,16 @@
             <!-- Year of publication -->
         </span>
 
-        <!-- Icons for different formats -->
-        <div class="inline-flex space-x-1">
-            <a><img src="/images/pdf.png" height="16" width="16" alt="PDF version of this item" /></a>
-            <a><img src="/images/logo-iiif-34x30.png" height="16" width="16" alt="IIIF manifest for this item" /></a>
-            <a><img src="/images/txt.png" height="16" width="16" alt="Plain text version of this item" /></a>
-            <a><img src="/images/alto-xml.png" height="16" width="16" alt="ALTO XML version of this item" /></a>
-            <a><img src="/images/other.png" height="16" width="16" alt="Alternative version of this item" /></a>
+
+
+        <!-- Different formats for download -->
+        <div class="flex flex-wrap items-baseline space-x-1 mt-1 text-gray-600 text-sm">
+            <span>Download:</span>
+            <a class="text-gray-600">PDF</a>
+            <a class="text-gray-600">IIIF</a>
+            <a class="text-gray-600">Plain-text</a>
+            <a class="text-gray-600">ALTO XML</a>
+            <a class="text-gray-600">Alternative</a>
         </div>
 
     </div>

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -65,7 +65,7 @@
             <a class="text-gray-600">IIIF</a>
             <a class="text-gray-600">Plain-text</a>
             <a class="text-gray-600">ALTO XML</a>
-            <a class="text-gray-600">Alternative</a>
+            <a class="text-gray-600">Other format</a>
         </div>
 
     </div>

--- a/public/scripts/SearchResults/Models/search-result.js
+++ b/public/scripts/SearchResults/Models/search-result.js
@@ -8,6 +8,8 @@
  * @property {?string} urlMain - The main URL to retrieve the record at.
  * @property {?string} urlPDF - The URL at which the record is kept in PDF format.
  * @property {?string} urlIIIF - The URL at which the record is kept in IIIF format.
+ * @property {?string} urlPlainText - The URL at which the record is kept in plaintext format.
+ * @property {?string} urlALTOXML - The URL at which the record is kept in ALTOXML format.
  * @property {?string[]} urlOther - Other relevant URLs for the record.
  * @property {Number} year - The year of publication
  */

--- a/public/scripts/SearchResults/ViewControllers/result-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/result-view-controller.js
@@ -28,8 +28,9 @@ export default class ResultViewController {
         this.SetInnerHTML(publisherDetails, publisherDetailsString);
 
 
-        let dlIcon = publisherDetails.nextElementSibling.firstElementChild;
-        const urls = [record.urlPDF, record.urlIIIF, record.urlPlainText, record.urlALTOXML, record.urlOther];
+        let dlIcon = publisherDetails.nextElementSibling.querySelector("a");
+        const urls = [record.urlPDF, record.urlIIIF, record.urlPlainText, record.urlALTOXML];
+
         for(let i = 0; i < urls.length; i++) {
             if (urls[i]) {
                 dlIcon.href = urls[i];
@@ -39,6 +40,20 @@ export default class ResultViewController {
                 dlIcon = dlIcon.nextElementSibling;
                 icon.parentElement.removeChild(icon);
             }
+        }
+        if(record.urlOther && record.urlOther.length > 0){
+            for(let i = 0; i < record.urlOther.length; i++){
+
+                if(i === 0) {
+                    dlIcon.href = record.urlOther[i]
+                } else {
+                    const icon = dlIcon.cloneNode(true);
+                    dlIcon.parentElement.appendChild(icon);
+                    icon.href = record.urlOther[i]
+                }
+            }
+        } else {
+            dlIcon.parentElement.removeChild(dlIcon);
         }
         return inflatedRecord;
     }

--- a/public/scripts/SearchResults/ViewControllers/result-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/result-view-controller.js
@@ -30,7 +30,22 @@ export default class ResultViewController {
 
         let dlIcon = publisherDetails.nextElementSibling.querySelector("a");
         const urls = [record.urlPDF, record.urlIIIF, record.urlPlainText, record.urlALTOXML];
+        let anyUrls = false;
+        for(let i = 0; i < urls; i++){
+            if(urls[i]) {
+                anyUrls = true;
+                break;
+            }
+        }
+        if(!anyUrls && record.urlOther && record.urlOther.length > 0) {
+            anyUrls = true;
+        }
 
+        if(!anyUrls){
+            const iconStrip = dlIcon.parentNode;
+            iconStrip.parentNode.removeChild(iconStrip);
+            return inflatedRecord;
+        }
         for(let i = 0; i < urls.length; i++) {
             if (urls[i]) {
                 dlIcon.href = urls[i];

--- a/public/scripts/SearchResults/ViewControllers/result-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/result-view-controller.js
@@ -31,7 +31,7 @@ export default class ResultViewController {
         let dlIcon = publisherDetails.nextElementSibling.querySelector("a");
         const urls = [record.urlPDF, record.urlIIIF, record.urlPlainText, record.urlALTOXML];
         let anyUrls = false;
-        for(let i = 0; i < urls; i++){
+        for(let i = 0; i < urls.length; i++){
             if(urls[i]) {
                 anyUrls = true;
                 break;


### PR DESCRIPTION
Less pretty, more usable.

I waffled a whole bunch on this, but ultimately I think, while the icons are visually appealing, using plain text links here is going to be the more usable solution. 
- Moving the links to a new line means they appear in a predictable location for every search result, so users can find them faster.
- Text is always readable and understandable—the icons require text labels for users to understand what they mean, but those labels are, by necessity, smaller and harder to read/zoom.
- Text is ultimately more accessible.
- Cohesive colour means they're visible, but don't draw the eye as much. This makes sense since they aren't the primary action here.

@stuartlewis What do you think about removing the icons in favour of plain-text links?

Before:
<img width="618" alt="Screenshot 2020-09-12 at 02 37 19" src="https://user-images.githubusercontent.com/376315/92984270-f6284380-f4a0-11ea-8143-12ad120cb863.png">

After:
<img width="663" alt="Screenshot 2020-09-12 at 02 45 22" src="https://user-images.githubusercontent.com/376315/92984443-08ef4800-f4a2-11ea-85da-326e9ede9d15.png">

Note: it looks as though "Other format" is showing up for every item, but it's never linked to anything. It's not super clear from the code why this isn't working, but it might be something @brizee can help out with before we merge this PR, if this is the direction in which we elect to go.
