### PR TITLE
feat: Add a modal menu

### DIFF
--- a/app/Common.php
+++ b/app/Common.php
@@ -23,3 +23,10 @@ function renderNavLink(string $path, string $name, string $current_path) {
         </li>
     <?php
 }
+
+// Get a reference for the current page.
+function getCurrentPage() {
+    $uri = current_url(true);
+    $current_path = "/" . $uri->getSegment(1);
+    return $current_path;
+}

--- a/app/Config/Solr.php
+++ b/app/Config/Solr.php
@@ -23,8 +23,8 @@ class Solr extends BaseConfig
             $this->solarium = array(
                 'endpoint' => array(
                     'localhost' => array(
-                        'host' => 'solr.opentexts.world',
-                        'port' => 80,
+                        'host' => '18.134.23.60',
+                        'port' => 8983,
                         'path' => '/',
                         'core' => 'otw-v2'
                     )

--- a/app/Config/Solr.php
+++ b/app/Config/Solr.php
@@ -23,8 +23,8 @@ class Solr extends BaseConfig
             $this->solarium = array(
                 'endpoint' => array(
                     'localhost' => array(
-                        'host' => '18.134.23.60',
-                        'port' => 8983,
+                        'host' => 'solr.opentexts.world',
+                        'port' => 80,
                         'path' => '/',
                         'core' => 'otw-v2'
                     )

--- a/app/Controllers/About.php
+++ b/app/Controllers/About.php
@@ -9,7 +9,7 @@ class About extends Controller
         $data['title'] = "About";
         
         echo view('templates/site-header', $data); 
-        echo view('templates/navigation-primary', $data);
+        echo view('templates/search-header', $data);
         echo view('about');
         echo view('templates/site-footer');
     }

--- a/app/Controllers/Contribute.php
+++ b/app/Controllers/Contribute.php
@@ -9,7 +9,7 @@ class Contribute extends Controller
         $data['title'] = "Contribute";
         
         echo view('templates/site-header', $data); 
-        echo view('templates/navigation-primary', $data);
+        echo view('templates/search-header', $data);
         echo view('contribute');
         echo view('templates/site-footer');
     }

--- a/app/Controllers/Help.php
+++ b/app/Controllers/Help.php
@@ -9,7 +9,7 @@ class Help extends Controller
         $data['title'] = "Help";
         
         echo view('templates/site-header', $data); 
-        echo view('templates/navigation-primary', $data);
+        echo view('templates/search-header', $data);
         echo view('help');
         echo view('templates/site-footer');
     }

--- a/app/Views/templates/navigation-modal.php
+++ b/app/Views/templates/navigation-modal.php
@@ -4,13 +4,11 @@
     </a>
   <ul class="navigation-modal ml-2">
     <?php
-            $uri = current_url(true);
-            $current_path = "/" . $uri->getSegment(1);
-
-            renderNavLink("/", "Home", $current_path);
-            renderNavLink("/about", "About", $current_path);
-            renderNavLink("/contribute", "Contribute", $current_path);
-            renderNavLink("/help", "Help", $current_path);
+        $current_path = getCurrentPage();
+        renderNavLink("/", "Home", $current_path);
+        renderNavLink("/about", "About", $current_path);
+        renderNavLink("/contribute", "Contribute", $current_path);
+        renderNavLink("/help", "Help", $current_path);
         ?>
   </ul>
 </nav>

--- a/app/Views/templates/navigation-modal.php
+++ b/app/Views/templates/navigation-modal.php
@@ -1,6 +1,7 @@
 <nav id="navigation-modal-wrapper" class="fixed top-0 right-0 bottom-0 z-10 bg-gray-200 p-4 w-full max-w-sm modal-closed">
     <a id="navigation-close" class="w-10 flex ml-auto flex-col justify-center items-center text-gray-700 no-underline cursor-pointer hover:text-blue-700">
-        <span class="text-opacity-50"><?php echo file_get_contents('svg/x.svg'); ?></span>
+        <span aria-hidden="true" class="text-opacity-50"><?php echo file_get_contents('svg/x.svg'); ?></span>
+        <span class="sr-only">Close</span>
     </a>
   <ul class="navigation-modal ml-2">
     <?php

--- a/app/Views/templates/navigation-modal.php
+++ b/app/Views/templates/navigation-modal.php
@@ -13,3 +13,9 @@
         ?>
   </ul>
 </nav>
+<?php
+if(!isset($data['payload'])) {
+    ?>
+    <script src="./scripts/static-page.js"></script>
+<?php
+}

--- a/app/Views/templates/navigation-modal.php
+++ b/app/Views/templates/navigation-modal.php
@@ -1,5 +1,5 @@
 <nav id="navigation-modal-wrapper" class="fixed top-0 right-0 bottom-0 z-10 bg-gray-200 p-4 w-full max-w-sm modal-closed">
-    <a id="navigation-close" class="w-10 flex ml-auto flex-col justify-center items-center text-gray-700 no-underline cursor-pointer hover:text-blue-700">
+    <a tabindex="0" id="navigation-close" class="w-10 flex ml-auto flex-col justify-center items-center text-gray-700 no-underline cursor-pointer hover:text-blue-700">
         <span aria-hidden="true" class="text-opacity-50"><?php echo file_get_contents('svg/x.svg'); ?></span>
         <span class="sr-only">Close</span>
     </a>

--- a/app/Views/templates/navigation-modal.php
+++ b/app/Views/templates/navigation-modal.php
@@ -1,0 +1,16 @@
+<nav id="navigation-modal-wrapper" class="fixed top-0 right-0 bottom-0 z-10 bg-gray-200 p-4 w-full max-w-sm modal-closed">
+    <a id="navigation-close" class="w-10 flex ml-auto flex-col justify-center items-center text-gray-700 no-underline cursor-pointer hover:text-blue-700">
+        <span class="text-opacity-50"><?php echo file_get_contents('svg/x.svg'); ?></span>
+    </a>
+  <ul class="navigation-modal ml-2">
+    <?php
+            $uri = current_url(true);
+            $current_path = "/" . $uri->getSegment(1);
+
+            renderNavLink("/", "Home", $current_path);
+            renderNavLink("/about", "About", $current_path);
+            renderNavLink("/contribute", "Contribute", $current_path);
+            renderNavLink("/help", "Help", $current_path);
+        ?>
+  </ul>
+</nav>

--- a/app/Views/templates/navigation-primary.php
+++ b/app/Views/templates/navigation-primary.php
@@ -1,9 +1,7 @@
 <nav class="container mx-auto pt-8 px-4 navigation-primary">
     <ul class="flex justify-center space-x-2 sm:space-x-8">
         <?php
-            $uri = current_url(true);
-            $current_path = "/" . $uri->getSegment(1);
-
+            $current_path = getCurrentPage();
             renderNavLink("/", "Home", $current_path);
             renderNavLink("/about", "About", $current_path);
             renderNavLink("/contribute", "Contribute", $current_path);

--- a/app/Views/templates/search-form.php
+++ b/app/Views/templates/search-form.php
@@ -1,5 +1,5 @@
 <form method="get" action="/search" class="container flex flex-col justify-center items-center max-w-xl">
-    <label class="block w-full text-white mb-1 pl-4 text-sm <?php echo isset($q) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
+    <label class="block w-full text-white mb-1 pl-4 text-sm <?php echo('/' !== getCurrentPage()) ? "sr-only" : "" ?>" for="search-input">Search by title, author, date, or subject</label>
 
     <div class="w-full bg-white rounded-full flex border-2 border-transparent" onfocusin="this.classList.add('search-focused')" onfocusout="this.classList.remove('search-focused')">
         <input name="q" type="search" id="search-input" class="w-full max-w-2xl py-2 pl-4 pr-8 rounded-full sm:px-1 sm:py-4 sm:pl-6 sm:pr-10 sm:text-lg text-gray-700 focus:outline-none focus:text-blue-700" value="<?php echo isset($q) ? esc($q) : "" ?>" />

--- a/app/Views/templates/search-header.php
+++ b/app/Views/templates/search-header.php
@@ -4,7 +4,7 @@
   <?php include('search-form.php'); ?>
     
     <a id="navigation-toggle" class="flex ml-2 xs:ml-0 flex-col justify-center items-center text-gray-100 no-underline cursor-pointer hover:text-blue-200">
-        <span class="text-opacity-50"><?php echo file_get_contents('svg/menu.svg'); ?></span>
+        <span aria-hidden="true" class="text-opacity-50"><?php echo file_get_contents('svg/menu.svg'); ?></span>
         <span class="text-xs sm:text-sm">Menu</span>
     </a>
   

--- a/app/Views/templates/search-header.php
+++ b/app/Views/templates/search-header.php
@@ -3,7 +3,7 @@
 
   <?php include('search-form.php'); ?>
     
-    <a id="navigation-toggle" class="flex ml-2 xs:ml-0 flex-col justify-center items-center text-gray-100 no-underline cursor-pointer hover:text-blue-200">
+    <a id="navigation-toggle" tabindex="0" class="flex ml-2 xs:ml-0 flex-col justify-center items-center text-gray-100 no-underline cursor-pointer hover:text-blue-200">
         <span aria-hidden="true" class="text-opacity-50"><?php echo file_get_contents('svg/menu.svg'); ?></span>
         <span class="text-xs sm:text-sm">Menu</span>
     </a>

--- a/app/Views/templates/search-header.php
+++ b/app/Views/templates/search-header.php
@@ -3,10 +3,11 @@
 
   <?php include('search-form.php'); ?>
     
-    <a class="flex ml-2 xs:ml-0 flex-col justify-center items-center text-gray-100 no-underline">
+    <a id="navigation-toggle" class="flex ml-2 xs:ml-0 flex-col justify-center items-center text-gray-100 no-underline cursor-pointer hover:text-blue-200">
         <span class="text-opacity-50"><?php echo file_get_contents('svg/menu.svg'); ?></span>
         <span class="text-xs sm:text-sm">Menu</span>
     </a>
-
+  
+    <?php include('navigation-modal.php'); ?>
 
 </header>

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -74,6 +74,9 @@
     <script type="module" src="./scripts/search-results.js"></script>
     <script>
         document.querySelectorAll(".filter").forEach(function(filter){
+            filter.addEventListener('click', function(event){
+                this._root.classList.add('filter-focus');
+            })
             filter.addEventListener('keydown', function(event){
                 if(!this.classList.contains('filter-focus'))
                 {

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -75,7 +75,7 @@
     <script>
         document.querySelectorAll(".filter").forEach(function(filter){
             filter.addEventListener('click', function(event){
-                this._root.classList.add('filter-focus');
+                this.classList.add('filter-focus');
             })
             filter.addEventListener('keydown', function(event){
                 if(!this.classList.contains('filter-focus'))

--- a/app/Views/templates/site-footer.php
+++ b/app/Views/templates/site-footer.php
@@ -18,6 +18,7 @@
                 <section>
                     <ul class="navigation-footer text-lg opacity-75">
                         <?php 
+                            $current_path = getCurrentPage();
                             renderNavLink("/", "Home", $current_path);
                             renderNavLink("/about", "About", $current_path);
                             renderNavLink("/contribute", "Contribute", $current_path);

--- a/app/Views/templates/site-footer.php
+++ b/app/Views/templates/site-footer.php
@@ -49,5 +49,6 @@
         </script>
         
         <script src="/scripts/focus-visible.min.js"></script>
+        <script src="/scripts/navigation-modal.js"></script>
     </body>
 </html>

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -97,6 +97,7 @@ p {
 
 .modal-closed {
     right: -24rem !important;
+    visibility: collapse;
 }
 
 /* Buttons */

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -61,7 +61,7 @@ p {
 }
 
 
-/* Footer mavigation links */
+/* Footer navigation links */
 .navigation-footer .navigation-link,
 .navigation-footer .navigation-link-current {
     @apply block text-blue-100 py-1 no-underline;
@@ -73,11 +73,36 @@ p {
     @apply text-blue-400;
 }
 
-.navigation-primary .navigation-link:focus,
-.navigation-primary .navigation-link-current:focus {
+.navigation-footer .navigation-link:focus,
+.navigation-footer .navigation-link-current:focus {
     @apply border-2 border-blue-400 p-2 text-white outline-none no-underline;
 }
 
+/* Modal navigation links */
+.navigation-modal .navigation-link,
+.navigation-modal .navigation-link-current {
+    @apply block text-blue-900 text-lg border-2 border-transparent p-2 no-underline;
+    transition: all 200ms ease-in-out;
+}
+
+.navigation-modal .navigation-link:hover,
+.navigation-modal .navigation-link-current:hover {
+    @apply text-blue-700;
+}
+
+.navigation-modal .navigation-link:focus,
+.navigation-modal .navigation-link-current:focus {
+    @apply border-blue-400 text-blue-700 outline-none no-underline;
+}
+
+/* Show and hide modal navigation */
+#navigation-modal-wrapper {
+    transition: all 200ms ease-in-out;
+}
+
+.modal-closed {
+    right: -24rem !important;
+}
 
 /* Buttons */
 .button-primary,

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -73,11 +73,6 @@ p {
     @apply text-blue-400;
 }
 
-.navigation-footer .navigation-link:focus,
-.navigation-footer .navigation-link-current:focus {
-    @apply border-2 border-blue-400 p-2 text-white outline-none no-underline;
-}
-
 /* Modal navigation links */
 .navigation-modal .navigation-link,
 .navigation-modal .navigation-link-current {

--- a/public/scripts/SearchResults/ViewControllers/filter-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/filter-view-controller.js
@@ -58,9 +58,7 @@ export default class FilterViewController {
     }
 
     onFocusChange() {
-        if (!this._root.classList.contains('filter-focus') && this._root.contains(document.activeElement)) {
-            this._root.classList.add('filter-focus');
-        } else if (this._root.classList.contains('filter-focus') && !this._root.contains(document.activeElement)) {
+        if (this._root.classList.contains('filter-focus') && !this._root.contains(document.activeElement)) {
             this._root.classList.remove('filter-focus');
         }
     }

--- a/public/scripts/navigation-modal.js
+++ b/public/scripts/navigation-modal.js
@@ -1,0 +1,7 @@
+document.getElementById('navigation-toggle').onclick = function(){
+    document.getElementById('navigation-modal-wrapper').classList.toggle('modal-closed');
+};
+
+document.getElementById('navigation-close').onclick = function(){
+    document.getElementById('navigation-modal-wrapper').classList.add('modal-closed');
+};

--- a/public/scripts/navigation-modal.js
+++ b/public/scripts/navigation-modal.js
@@ -35,7 +35,8 @@ function navKeyboardHandler(event){
                 event.preventDefault();
                 break;
             case 13:
-                document.activeElement.querySelector("a").click();
+                var link  = document.activeElement.querySelector("a") || document.activeElement;
+                link.click()
                 event.preventDefault();
         }
     }

--- a/public/scripts/navigation-modal.js
+++ b/public/scripts/navigation-modal.js
@@ -1,7 +1,60 @@
-document.getElementById('navigation-toggle').onclick = function(){
-    document.getElementById('navigation-modal-wrapper').classList.toggle('modal-closed');
+const navToggleButton = document.getElementById('navigation-toggle');
+const navModalWrapper = document.getElementById('navigation-modal-wrapper');
+const navLinks = Array.from(navModalWrapper.querySelectorAll("li>a"));
+
+function navKeyboardHandler(event){
+    let currentIndex = navLinks.indexOf(document.activeElement);
+    if(navModalWrapper.classList.contains('modal-closed'))
+    {
+        if(event.keyCode === 13 || event.keyCode === 32)
+        {
+            navModalWrapper.classList.remove('modal-closed');
+            event.preventDefault();
+            setTimeout(() =>navLinks[0].focus(), 200);
+        }
+    }
+    else {
+        switch (event.keyCode) {
+            case 27:
+                navModalWrapper.classList.add('modal-closed');
+                navToggleButton.focus();
+                event.preventDefault();
+                break;
+            case 38:
+                if (currentIndex > 0) {
+                    currentIndex--;
+                }
+                navLinks[currentIndex].focus();
+                event.preventDefault();
+                break;
+            case 40:
+                if (currentIndex < navLinks.length - 1) {
+                    currentIndex++;
+                }
+                navLinks[currentIndex].focus();
+                event.preventDefault();
+                break;
+            case 13:
+                document.activeElement.querySelector("a").click();
+                event.preventDefault();
+        }
+    }
+}
+
+navToggleButton.onclick = function(){
+    navModalWrapper.classList.toggle('modal-closed');
+    navLinks[0].focus();
 };
 
+navToggleButton.addEventListener("keydown", navKeyboardHandler);
+navModalWrapper.addEventListener("keydown", navKeyboardHandler);
+
 document.getElementById('navigation-close').onclick = function(){
-    document.getElementById('navigation-modal-wrapper').classList.add('modal-closed');
+    navModalWrapper.classList.add('modal-closed');
 };
+
+function navHandleFocusChange(){
+    if(!navModalWrapper.classList.contains('modal-closed') && !navModalWrapper.contains(document.activeElement)) {
+        navModalWrapper.classList.add('modal-closed');
+    }
+}

--- a/public/scripts/search-results.js
+++ b/public/scripts/search-results.js
@@ -11,11 +11,13 @@ const filterViewControllers = Array.from(document.querySelectorAll(".filter")).m
 
 function detectFocus(){
     filterViewControllers.forEach(fvc => fvc.onFocusChange());
+    navHandleFocusChange();
 }
 
 function detectBlur() {
     setTimeout(function() {
         filterViewControllers.forEach(fvc => fvc.onFocusChange());
+        navHandleFocusChange();
     }, 0);
 }
 window.addEventListener ? window.addEventListener('focus', detectFocus, true) : window.attachEvent('onfocusout', detectFocus);

--- a/public/scripts/static-page.js
+++ b/public/scripts/static-page.js
@@ -1,0 +1,14 @@
+
+function detectFocus(){
+    navHandleFocusChange();
+}
+
+function detectBlur() {
+    setTimeout(function() {
+        navHandleFocusChange();
+    }, 0);
+}
+
+window.addEventListener ? window.addEventListener('focus', detectFocus, true) : window.attachEvent('onfocusout', detectFocus);
+
+window.addEventListener ? window.addEventListener('blur', detectBlur, true) : window.attachEvent('onblur', detectBlur);

--- a/public/svg/x.svg
+++ b/public/svg/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>


### PR DESCRIPTION
Finally!

<img width="919" alt="Screenshot 2020-09-14 at 13 39 45" src="https://user-images.githubusercontent.com/376315/93086956-cee39900-f68f-11ea-93e9-fbafc3b5675f.png">

I wound up borrowing some of @stuartlewis' Javascript from #114, but I've used a slightly different approach. I first tried working on top of that branch, but I think because it's coming from a forked repo, attempting to merge the main branch back in resulted it a whole slew of merge conflicts, so it was easiest here to just start from scratch, so we'll close #114 in favour of this PR, once we have all the details worked out.

This needs a little help to be merge-ready—it works, but it's not quite as accessible as it should be and behaves unexpectedly when navigating via the keyboard. 

Here's what I've found so far:
- [ ] The menu opens automatically, rather than specifically on selecting the menu button. This feels like unexpected behaviour.
- [ ] There's no way to then CLOSE the menu easily with the keyboard.
- [ ] The escape key should allow users to close the menu.
- [ ] Clicking outside the menu overlay should close the menu.
- [ ] We may need to use more aria labels to ensure full support for assistive devices.

There may be things I've missed here, too. 

I'd super appreciate some help with the above from someone a little more technical than myself, since I suspect it's all going to involve lots of JS. (There are also [pure CSS solutions](https://medium.com/@heyoka/responsive-pure-css-off-canvas-hamburger-menu-aebc8d11d793), but those are also pretty technical. If we don't anticipate many visitors will have JS turned off, a JS-based solution seems fine here.)

@brizee or @stuartlewis perhaps you might be able to take a crack at this? I can help with any visual/CSS stuff that needs additional fine-tuning once we have everything working nicely. 😄 