### PR TITLE
More advanced search filtering

### DIFF
--- a/app/Controllers/Search.php
+++ b/app/Controllers/Search.php
@@ -1,5 +1,6 @@
 <?php namespace App\Controllers;
 
+use App\Models\OTQuery;
 use CodeIgniter\Controller;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Curl;
@@ -19,30 +20,8 @@ class Search extends Controller
     {
         $config = config('Solr');
 
-        // TODO Make much more robust (if is_empty($q)) etc
-        $q = filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS);
+        $q = new OTQuery(filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS));
 
-        // Quick fix for quotes around searches
-        $q = str_replace("&#34;", '"', $q);
-        $q = str_replace("&#39;", "'", $q);
-
-        // Quick fix if there is an odd number of double quotes
-        if (substr_count($q, '"') % 2 == 1) { $q .= '"'; }
-
-        // Store the query
-        $data['q'] = $q;
-
-        // Fix special solr characters - only add fixes here for solr, not for HTML (see a few lines above)
-        $q = str_replace(":", '\:', $q);
-        $q = str_replace("[", '\[', $q);
-        $q = str_replace("]", '\]', $q);
-        $q = str_replace("{", '\{', $q);
-        $q = str_replace("}", '\}', $q);
-        $q = str_replace("~", '\~', $q);
-
-        if ((empty($q)) || ($q == "")) {
-            $q = "*";
-        }
 
         // Create a client instance
         $client = new Client($config->solarium);
@@ -54,14 +33,13 @@ class Search extends Controller
                 
         // Get a select query instance
         $query = $client->createSelect();
-        $query->setQuery($q);
-        
+        $q->applyQuery($query);
         // Only bring back the fields required
         $query->setFields(array('organisation', 'title', 'urlMain', 'creator', 'publisher', 'placeOfPublication', 'year', 
                                 'urlPDF', 'urlIIIF', 'urlPlainText', 'urlALTOXML', 'urlOther'));
         
         // Generate the URL without pagination details
-        $url = '/search/?q=' . $q;
+        $url = '/search/?q=' . $q->sanitisedQuery;
 
         // Was an organisation facet selected?
         $organisation = filter_input(INPUT_GET, 'organisation', FILTER_SANITIZE_SPECIAL_CHARS);
@@ -95,6 +73,7 @@ class Search extends Controller
 
         $count = 10;
         $query->setRows($count);
+        $query->addSort("score", "desc");
         // Get the facetset component
         $facetSet = $query->getFacetSet();
 
@@ -111,6 +90,7 @@ class Search extends Controller
         $resultset = $client->select($query);
 
         // Send the parameters to the view
+        $data['q'] = $q->sanitisedQuery;
         $data['resultcount'] = $resultset->getNumFound();
         $data['organisationfacet'] = $resultset->getFacetSet()->getFacet('orgf');
         $data['languagefacet'] = $resultset->getFacetSet()->getFacet('langf');
@@ -210,25 +190,14 @@ class Search extends Controller
         $config = config('Solr');        
         
         // TODO Make much more robust (if is_empty($q)) etc
-        $q = filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS);
-        
-        // Quick fix for double quotes around searches
-        $q = str_replace("&#34;", '"', $q);
-        
-        // Fix special solr characters - only add fixes here for solr, not for HTML (see a few lines above)
-        $q = str_replace(":", '\:', $q);
-        $q = str_replace("[", '\[', $q);
-        $q = str_replace("]", '\]', $q);
-        $q = str_replace("{", '\{', $q);
-        $q = str_replace("}", '\}', $q);
-        $q = str_replace("~", '\~', $q);
+        $q = new OTQuery(filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS));
 
         // Generate the solr search URL
         $url = "http://" . $config->solarium['endpoint']['localhost']['host'] .
                ":" . $config->solarium['endpoint']['localhost']['port'] .
                $config->solarium['endpoint']['localhost']['path'] .
                "solr/" . $config->solarium['endpoint']['localhost']['core'] .
-               "/select?q=" . urlencode($q);
+               "/select?q=" . urlencode($q->getQuery());
         
         // Was an organisation facet selected?
         $organisation = filter_input(INPUT_GET, 'organisation', FILTER_SANITIZE_SPECIAL_CHARS);

--- a/app/Models/OTQuery.php
+++ b/app/Models/OTQuery.php
@@ -1,0 +1,148 @@
+<?php
+namespace App\Models;
+
+use Solarium\QueryType\Select\Query\Query;
+
+class EContext {
+    const GLOBAL = 0;
+    const QUOTES = 1;
+}
+
+class OTQuery
+{
+    public $isValid = true;
+    public $sanitisedQuery = "";
+    private $solrSafeQuery = "";
+
+    function __construct(string $q) {
+
+        $q = html_entity_decode($q);
+
+        $this->sanitisedQuery = $q;
+
+        $q = urldecode($q);
+        $chars = str_split($q);
+        $context = EContext::GLOBAL;
+
+
+        $term = array();
+        $mandatoryFlag = false;
+        $notIncludeFlag = false;
+        $endTermFlag = false;
+        $enterQuoteContext = false;
+        $exitQuoteContext = false;
+        foreach ($chars as $char){
+            switch($char)
+            {
+                case "\"":
+                    if(count($term) > 0) {
+                        $endTermFlag = true;
+                    }
+                    if($context == EContext::GLOBAL) {
+                        $enterQuoteContext = true;
+                    } else {
+                        $exitQuoteContext = true;
+                    }
+                    break;
+                case "+":
+                    if(count($term) == 0) {
+                        $mandatoryFlag = true;
+                    } else {
+                        $endTermFlag = true;
+                    }
+                    break;
+                case "-":
+                case "!":
+                    if(count($term) == 0) {
+                        $notIncludeFlag = true;
+                    } else {
+                        $endTermFlag = true;
+                    }
+                    break;
+                case " ":
+                    if($context == EContext::GLOBAL) {
+                        $endTermFlag = true;
+                    } else {
+                        array_push($term, $char);
+                    }
+                case "&":   // No search relevance
+                case "|":
+                case "^":
+                    break;
+                case "(":   // Escape character and proceed
+                case ")":
+                case "[":
+                case "]":
+                case "{":
+                case "}":
+                case "~":
+                case "*":
+                case "?":
+                case ":":
+                case "/":
+                    array_push($term, "\\", $char);
+                    break;
+                default:
+                    array_push($term, $char);
+                    break;
+            }
+            if($exitQuoteContext) {
+                $context = EContext::GLOBAL;
+                $exitQuoteContext = false;
+            }
+            if($endTermFlag && $context != EContext::QUOTES) {
+                $this->solrSafeQuery .= $this->buildQueryPart($term, $mandatoryFlag, $notIncludeFlag);
+                $term = array();
+                $endTermFlag = false;
+                $mandatoryFlag = false;
+                $notIncludeFlag = false;
+            }
+            if($enterQuoteContext) {
+                $context = EContext::QUOTES;
+                $enterQuoteContext = false;
+                if(!$notIncludeFlag) {
+                    $mandatoryFlag = true; // Quotes are implicitly mandatory unless expressly countered
+                }
+            }
+        }
+        $this->solrSafeQuery .= $this->buildQueryPart($term, $mandatoryFlag, $notIncludeFlag);
+
+        if ((empty($this->solrSafeQuery)) || ($this->solrSafeQuery == "")) {
+            $this->solrSafeQuery = "*";
+        }
+    }
+
+    function buildQueryPart(Array $term, bool $mustInclude, bool $mustNotInclude) : string {
+        $finalTerm = implode($term);
+        $multiWord = str_contains($finalTerm, " ");
+        $expr = "";
+        $lcase = strtolower($finalTerm);
+        if($lcase == "and" || $lcase == "or") {
+            return $expr;
+        }
+        if($mustInclude) {
+            $expr .= "+";
+        } else if($mustNotInclude) {
+            $expr .= "-";
+        }
+        if($multiWord) {
+            $expr .= "\"";
+        }
+        $expr .= $finalTerm;
+        if($multiWord) {
+            $expr .= "\"";
+        } elseif (strlen($finalTerm) > 5 && !$mustInclude && !$mustNotInclude){
+            $expr .= "~";
+        }
+        $expr .= " ";
+        return $expr;
+    }
+
+    function applyQuery(Query &$query) {
+        $query->setQuery($this->solrSafeQuery);
+    }
+
+    function getQuery() : String{
+        return $this->solrSafeQuery;
+    }
+}


### PR DESCRIPTION
Did a bit of a rework of input processing to better align with what solr expects, some examples:

* `cpucake` becomes `cpucake~` engaging Solr's fuzzy search and returning cupcake entries.
![image](https://user-images.githubusercontent.com/188324/93671104-2327b800-fa98-11ea-9d5b-0564198b71d2.png)

* `cupcake -"give a cat" -queen` - I'm not entirely sure what happens here as after processing both should be pretty similar actually, new processing filters out the entries you could see in the last image, old processing filters from ~500 entries to 8 with seemingly less relevance?
![image](https://user-images.githubusercontent.com/188324/93671181-b365fd00-fa98-11ea-9b47-4d5d99b177dc.png)

* `Eating and drinking` - New processing changes this to `Eating drinking`, old processing interprets it as `Eating && drinking` (i.e. both terms become mandatory)
![image](https://user-images.githubusercontent.com/188324/93671223-1c4d7500-fa99-11ea-90de-8fd31f320594.png)

* `Books by "George Orwell"` - new processing now interprets this as `Books by +"George Orwell"` result being old provides 5,114,394 results that may just match the "Books by" portion and new processing returns 36 results containing the exact phrase "George Orwell"

This is my interpretation but we can flex these rules quite a bit :smile: