### PR TITLE
feat: Style Contribute page

### DIFF
--- a/app/Views/contribute.php
+++ b/app/Views/contribute.php
@@ -31,25 +31,27 @@
         Repeatable fields must be separated with a '|' pipe.
     </p>
     
-    <table class="my-12 md:-mx-40 md:max-w-screen-lg lg:-mx-64 lg:max-w-screen-2xl">
-        <thead class="thead-dark">
+    <table class="my-12 md:-mx-40 md:max-w-screen-lg table-auto border">
+        <thead>
             <tr>
-                <th scope="col">Column</th>
-                <th scope="col">Heading</th>
-                <th scope="col">Content</th>
-                <th scope="col">Requirement</th>
-                <th scope="col">Repeatable</th>
-                <th scope="col">Notes</th>
+                <th scope="col" class="contribute-table__header">Column</th>
+                <th scope="col" class="contribute-table__header">Heading</th>
+                <th scope="col" class="contribute-table__header">Content</th>
+                <th scope="col" class="contribute-table__header">Requirement</th>
+                <th scope="col" class="contribute-table__header">Repeatable</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <th scope="row">1</th>
-                <td>organisation</td>
-                <td>Unique name of provider</td>
-                <td>MANDATORY</td>
-                <td>No</td>
-                <td>
+                <th scope="row" class="contribute-table__cell">1</th>
+                <td class="contribute-table__cell">organisation</td>
+                <td class="contribute-table__cell">Unique name of provider</td>
+                <td class="contribute-table__cell">Mandatory</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     So we know which organisation contributed the metadata and content - 
                     this info will be displayed in a facet and in the full record display. E.g.:<br />
                     <br />
@@ -59,186 +61,256 @@
                 </td>
             </tr>
             <tr>
-                <th scope="row">2</th>
-                <td>idLocal</td>
-                <td>Local identifier</td>
-                <td>MANDATORY</td>
-                <td>No</td>
-                <td>
+                <th scope="row" class="contribute-table__cell">2</th>
+                <td class="contribute-table__cell">idLocal</td>
+                <td class="contribute-table__cell">Local identifier</td>
+                <td class="contribute-table__cell">Mandatory</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     ID from the local system - so each library can look up their 
                     local system if there's a query 
                 </td>
             </tr>
             <tr>
-                <th scope="row">3</th>
-                <td>title</td>
-                <td>Title of the work</td>
-                <td>MANDATORY</td>
-                <td>No</td>
-                <td>
+                <th scope="row" class="contribute-table__cell">3</th>
+                <td class="contribute-table__cell">title</td>
+                <td class="contribute-table__cell">Title of the work</td>
+                <td class="contribute-table__cell">Mandatory</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     For example <a href="https://www.loc.gov/marc/bibliographic/concise/bd245.html">MARC 245 $a $b</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/title">DC terms:title</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">4</th>
-                <td>urlMain</td>
-                <td>URL to access the item</td>
-                <td>MANDATORY</td>
-                <td>No</td>
-                <td>
+                <th class="contribute-table__cell">4</th>
+                <td class="contribute-table__cell">urlMain</td>
+                <td class="contribute-table__cell">URL to access the item</td>
+                <td class="contribute-table__cell">Mandatory</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     The URL that is most appropriate for a user to follow to get direct/immediate access to the
                     content. May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd856.html">MARC 856</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/identifier">DC terms:identifier</a>. This will likely be a 'landing page' containing metadata about the item and the item itself.
                 </td>
             </tr>
             <tr>
-                <th scope="row">5</th>
-                <td>year</td>
-                <td>Year of publication</td>
-                <td>DESIRABLE</td>
-                <td>No</td>
-                <td>
+                <th class="contribute-table__cell">5</th>
+                <td class="contribute-table__cell">year</td>
+                <td class="contribute-table__cell">Year of publication</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     This needs to be numeric and four digits in length as it is used to feed the year filter.
                 </td>
             </tr>
             <tr>
-                <th scope="row">6</th>
-                <td>date</td>
-                <td>Date of publication</td>
-                <td>DESIRABLE</td>
-                <td>No</td>
-                <td>
+                <th class="contribute-table__cell">6</th>
+                <td class="contribute-table__cell">date</td>
+                <td class="contribute-table__cell">Date of publication</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     Ideally numeric but can be any value, <a href="https://www.loc.gov/marc/bibliographic/concise/bd008a.html">MARC 008 position 7-10</a> rather than 
                     MARC 260 $c - e.g. preferred to 1884 vs ca.1884). May be in <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date">DC terms:date</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">7</th>
-                <td>publisher</td>
-                <td>Publisher</td>
-                <td>DESIRABLE</td>
-                <td>Yes</td>
-                <td>
+                <th class="contribute-table__cell">7</th>
+                <td class="contribute-table__cell">publisher</td>
+                <td class="contribute-table__cell">Publisher</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">Yes</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $b</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">DC terms:publisher</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">8</th>
-                <td>creator</td>
-                <td>Creator</td>
-                <td>DESIRABLE</td>
-                <td>Yes</td>
-                <td>
+                <th class="contribute-table__cell">8</th>
+                <td class="contribute-table__cell">creator</td>
+                <td class="contribute-table__cell">Creator</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">Yes</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     Author, editor, creator, organisation - any named person/organisation involved in the creation of the work. May be in MARC <a href="https://www.loc.gov/marc/bibliographic/bd1xx.html">1xx</a>, <a href="https://www.loc.gov/marc/bibliographic/bd70x75x.html">7xx</a> and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/creator">DC terms:creator</a>, <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/contributor">DC terms:contributor</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">9</th>
-                <td>topic</td>
-                <td>Subject or topic</td>
-                <td>DESIRABLE</td>
-                <td>Yes</td>
-                <td>May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>
+                <th class="contribute-table__cell">9</th>
+                <td class="contribute-table__cell">topic</td>
+                <td class="contribute-table__cell">Subject or topic</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">Yes</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">10</th>
-                <td>description</td>
-                <td>Description</td>
-                <td>DESIRABLE</td>
-                <td>Yes</td>
-                <td>
+                <th class="contribute-table__cell">10</th>
+                <td class="contribute-table__cell">description</td>
+                <td class="contribute-table__cell">Description</td>
+                <td class="contribute-table__cell">Desireable</td>
+                <td class="contribute-table__cell">Yes</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     Description about the content. May be in <a href="https://www.loc.gov/marc/bibliographic/bd5xx.html">MARC 5xx</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/description">DC terms:description</a>
                 </td>
             </tr>
             <tr>
-                <th scope="row">11</th>
-                <td>urlPDF</td>
-                <td>URL of a PDF</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>
+                <th class="contribute-table__cell">11</th>
+                <td class="contribute-table__cell">urlPDF</td>
+                <td class="contribute-table__cell">URL of a PDF</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     If there is a PDF version of the item
                 </td>
             </tr>
             <tr>
-                <th scope="row">12</th>
-                <td>urlIIIF</td>
-                <td>URL to a IIIF manifest</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>URL to a IIIF manifest</td>
+                <th class="contribute-table__cell">12</th>
+                <td class="contribute-table__cell">urlIIIF</td>
+                <td class="contribute-table__cell">URL to a IIIF manifest</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
             </tr>
             <tr>
-                <th scope="row">13</th>
-                <td>urlPlainText</td>
-                <td>URL to a plain text file</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>URL to a plain text file</td>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    URL to a IIIF manifest
+                </td>
             </tr>
             <tr>
-                <th scope="row">14</th>
-                <td>urlALTOXML</td>
-                <td>URL to an ALTO XML file</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>URL to an <a href="https://en.wikipedia.org/wiki/ALTO_(XML)">ALTO XML</a> file</td>
+                <th class="contribute-table__cell">13</th>
+                <td class="contribute-table__cell">urlPlainText</td>
+                <td class="contribute-table__cell">URL to a plain text file</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+                </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    URL to a plain text file
+                </td>
             </tr>
             <tr>
-                <th scope="row">15</th>
-                <td>urlOther</td>
-                <td>URL of other useful version(s)</td>
-                <td>OPTIONAL</td>
-                <td>Yes</td>
-                <td>
+                <th class="contribute-table__cell">14</th>
+                <td class="contribute-table__cell">urlALTOXML</td>
+                <td class="contribute-table__cell">URL to an ALTO XML file</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    URL to an <a href="https://en.wikipedia.org/wiki/ALTO_(XML)">ALTO XML</a> file
+                </td>
+            </tr>
+            <tr>
+                <th class="contribute-table__cell">15</th>
+                <td class="contribute-table__cell">urlOther</td>
+                <td class="contribute-table__cell">URL of other useful version(s)</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">Yes</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     If there are other URLs for the content that may be useful - perhaps 
                     Google Books URL, or link to the catalogue record of the original
                 </td>
             </tr>
             <tr>
-                <th scope="row">16</th>
-                <td>placeOfPublication</td>
-                <td>Place of publication</td>
-                <td>OPTIONAL</td>
-                <td>Yes</td>
-                <td>May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a></td>
+                <th class="contribute-table__cell">16</th>
+                <td class="contribute-table__cell">placeOfPublication</td>
+                <td class="contribute-table__cell">Place of publication</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">Yes</td>
             </tr>
             <tr>
-                <th scope="row">17</th>
-                <td>licence</td>
-                <td>Licence of the material</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a>
+                </td>
+            </tr>
+            <tr>
+                <th class="contribute-table__cell">17</th>
+                <td class="contribute-table__cell">licence</td>
+                <td class="contribute-table__cell">Licence of the material</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd540.html">MARC 540</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">DC terms:rights</a><br/>
                     <br/>
                     For example CC-BY
                 </td>
             </tr>
             <tr>
-                <th scope="row">18</th>
-                <td>idOther</td>
-                <td>Other local or external ids</td>
-                <td>OPTIONAL</td>
-                <td>Yes</td>
-                <td>Other identifiers such as DOIs</td>
+                <th class="contribute-table__cell">18</th>
+                <td class="contribute-table__cell">idOther</td>
+                <td class="contribute-table__cell">Other local or external ids</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">Yes</td>
             </tr>
             <tr>
-                <th scope="row">19</th>
-                <td>catLink</td>
-                <td>A link directly to the item's catalogue record</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>A link to the item in your catalogue or discovery system</td>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    Other identifiers such as DOIs
+                </td>
             </tr>
             <tr>
-                <th scope="row">20</th>
-                <td>language</td>
-                <td>language of the resource</td>
-                <td>OPTIONAL</td>
-                <td>No</td>
-                <td>
+                <th class="contribute-table__cell">19</th>
+                <td class="contribute-table__cell">catLink</td>
+                <td class="contribute-table__cell">A link directly to the item's catalogue record</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
+                    A link to the item in your catalogue or discovery system
+                </td>
+            </tr>
+            <tr>
+                <th class="contribute-table__cell">20</th>
+                <td class="contribute-table__cell">language</td>
+                <td class="contribute-table__cell">language of the resource</td>
+                <td class="contribute-table__cell">Optional</td>
+                <td class="contribute-table__cell">No</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="contribute-table__notes"></td>
+                <td colspan="3" class="contribute-table__notes">
                     May be in MARC 008 position 35-37 and/or  MARC 041.<a href="https://www.loc.gov/marc/languages/">[code list]</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/language">DC terms:language</a>.
                     Additional default values of 'Not specified' and 'Undetermined'

--- a/app/Views/contribute.php
+++ b/app/Views/contribute.php
@@ -30,7 +30,7 @@
         Repeatable fields must be separated with a '|' pipe.
     </p>
     
-    <table class="my-12 md:-mx-40 md:max-w-screen-lg table-auto border">
+    <table class="my-6 w-full md:my-12 md:table-auto md:w-auto md:-mx-24 md:max-w-screen lg:-mx-40 lg:max-w-screen-lg border">
         <thead>
             <tr>
                 <th scope="col" class="contribute-table__header">Column</th>
@@ -48,9 +48,9 @@
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2" ></td>
+                <td colspan="3">
                     So we know which organisation contributed the metadata and content. This info will be displayed in a facet and in the full record display. E.g.: <em>Wellcome Library</em>, <em>National Library of Scotland</em>, <em>HathiTrust</em>.
                 </td>
             </tr>
@@ -61,9 +61,9 @@
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     ID from the local system - so each library can look up their 
                     local system if there's a query. 
                 </td>
@@ -75,9 +75,9 @@
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     For example <a href="https://www.loc.gov/marc/bibliographic/concise/bd245.html">MARC 245 $a $b</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/title">DC terms:title</a>.
                 </td>
             </tr>
@@ -88,9 +88,9 @@
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     The URL that is most appropriate for a user to follow to get direct/immediate access to the
                     content. May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd856.html">MARC 856</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/identifier">DC terms:identifier</a>. This will likely be a 'landing page' containing metadata about the item and the item itself.
@@ -103,9 +103,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     This needs to be numeric and four digits in length as it is used to feed the year filter.
                 </td>
             </tr>
@@ -116,9 +116,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     Ideally numeric but can be any value. <a href="https://www.loc.gov/marc/bibliographic/concise/bd008a.html">MARC 008 position 7-10</a> rather than 
                     MARC 260 $c - e.g. preferred to 1884 vs ca.1884). May be in <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date">DC terms:date</a>.
                 </td>
@@ -130,9 +130,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $b</a>, <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a>, or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">DC terms:publisher</a>.
                 </td>
             </tr>
@@ -143,9 +143,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     Author, editor, creator, organisation - any named person or organisation involved in the creation of the work. May be in MARC <a href="https://www.loc.gov/marc/bibliographic/bd1xx.html">1xx</a>, <a href="https://www.loc.gov/marc/bibliographic/bd70x75x.html">7xx</a> and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/creator">DC terms:creator</a>, <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/contributor">DC terms:contributor</a>.
                 </td>
             </tr>
@@ -156,9 +156,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>.
                 </td>
             </tr>
@@ -169,9 +169,9 @@
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     Description about the content. May be in <a href="https://www.loc.gov/marc/bibliographic/bd5xx.html">MARC 5xx</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/description">DC terms:description</a>.
                 </td>
             </tr>
@@ -210,9 +210,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     If there are other URLs for the content that may be useful - perhaps 
                     Google Books URL, or link to the catalogue record of the original.
                 </td>
@@ -224,9 +224,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                 May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a>.
                 </td>
             </tr>
@@ -237,9 +237,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd540.html">MARC 540</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">DC terms:rights</a>. 
                     For example CC-BY.
                 </td>
@@ -251,9 +251,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     Other local or external identifiers such as DOIs.
                 </td>
             </tr>
@@ -264,9 +264,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     A link to the item in your catalogue or discovery system.
                 </td>
             </tr>
@@ -277,9 +277,9 @@
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
+            <tr class="contribute-table__notes">
+                <td colspan="2"></td>
+                <td colspan="3">
                     May be in MARC 008 position 35-37 and/or  MARC 041.<a href="https://www.loc.gov/marc/languages/">[code list]</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/language">DC terms:language</a>.
                     Additional default values of 'Not specified' and 'Undetermined'.

--- a/app/Views/contribute.php
+++ b/app/Views/contribute.php
@@ -1,9 +1,9 @@
 <main role="main" class="container main-container">
     <article class="mx-auto max-w-xl">
-    <h1>Become a data contributor</h1>
+    <h1>Contribute data</h1>
     <p class="intro">
         If you would like to contribute data to be included in OpenTexts.World, please email 
-        <a href="mailto:stuart.lewis@nls.uk; gill.hamilton@nls.uk">stuart.lewis@nls.uk and gill.hamilton@nls.uk</a>
+        <a href="mailto:stuart.lewis@nls.uk?&cc=gill.hamilton@nls.uk">stuart.lewis@nls.uk and gill.hamilton@nls.uk</a>
         for details.
     </p>
 	
@@ -11,13 +11,12 @@
     <p>
         We can work with <a href="https://www.loc.gov/marc/bibliographic/" title="MARC21 at Library of Congress, USA">MARC21</a>, 
         <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/" title="DC terms">Dublin Core</a> or 
-        <a href="https://en.wikipedia.org/wiki/Comma-separated_values" title="comma-separated value at Wikipedia">CSV</a> (comma-separated) files in the format below.
-        We have also been able to harvest data via <a href="https://www.openarchives.org/pmh/">OAI-PMH</a> and
+        <a href="https://en.wikipedia.org/wiki/Comma-separated_values" title="comma-separated value at Wikipedia">CSV</a> (comma-separated) files in the format below. We have also been able to harvest data via <a href="https://www.openarchives.org/pmh/">OAI-PMH</a> and
         <a href="https://iiif.io/">IIIF discovery</a>, or via custom existing data feeds and APIs.
     </p>
 
     <p>
-        If your data is in another format, please <a href="mailto:stuart.lewis@nls.uk; gill.hamilton@nls.uk">contact us</a> 
+        If your data is in another format, please <a href="mailto:stuart.lewis@nls.uk?&cc=gill.hamilton@nls.uk">contact us</a> 
         as we may be able to process and integrate it. We love a challenge!
     </p>
     
@@ -47,17 +46,12 @@
                 <td class="contribute-table__cell">organisation</td>
                 <td class="contribute-table__cell">Unique name of provider</td>
                 <td class="contribute-table__cell">Mandatory</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    So we know which organisation contributed the metadata and content - 
-                    this info will be displayed in a facet and in the full record display. E.g.:<br />
-                    <br />
-                    Wellcome Library<br />
-                    National Library of Scotland<br />
-                    HathiTrust
+                    So we know which organisation contributed the metadata and content. This info will be displayed in a facet and in the full record display. E.g.: <em>Wellcome Library</em>, <em>National Library of Scotland</em>, <em>HathiTrust</em>.
                 </td>
             </tr>
             <tr>
@@ -65,13 +59,13 @@
                 <td class="contribute-table__cell">idLocal</td>
                 <td class="contribute-table__cell">Local identifier</td>
                 <td class="contribute-table__cell">Mandatory</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
                     ID from the local system - so each library can look up their 
-                    local system if there's a query 
+                    local system if there's a query. 
                 </td>
             </tr>
             <tr>
@@ -79,12 +73,12 @@
                 <td class="contribute-table__cell">title</td>
                 <td class="contribute-table__cell">Title of the work</td>
                 <td class="contribute-table__cell">Mandatory</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    For example <a href="https://www.loc.gov/marc/bibliographic/concise/bd245.html">MARC 245 $a $b</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/title">DC terms:title</a>
+                    For example <a href="https://www.loc.gov/marc/bibliographic/concise/bd245.html">MARC 245 $a $b</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/title">DC terms:title</a>.
                 </td>
             </tr>
             <tr>
@@ -92,7 +86,7 @@
                 <td class="contribute-table__cell">urlMain</td>
                 <td class="contribute-table__cell">URL to access the item</td>
                 <td class="contribute-table__cell">Mandatory</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
@@ -107,7 +101,7 @@
                 <td class="contribute-table__cell">year</td>
                 <td class="contribute-table__cell">Year of publication</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
@@ -120,13 +114,13 @@
                 <td class="contribute-table__cell">date</td>
                 <td class="contribute-table__cell">Date of publication</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    Ideally numeric but can be any value, <a href="https://www.loc.gov/marc/bibliographic/concise/bd008a.html">MARC 008 position 7-10</a> rather than 
-                    MARC 260 $c - e.g. preferred to 1884 vs ca.1884). May be in <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date">DC terms:date</a>
+                    Ideally numeric but can be any value. <a href="https://www.loc.gov/marc/bibliographic/concise/bd008a.html">MARC 008 position 7-10</a> rather than 
+                    MARC 260 $c - e.g. preferred to 1884 vs ca.1884). May be in <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date">DC terms:date</a>.
                 </td>
             </tr>
             <tr>
@@ -134,12 +128,12 @@
                 <td class="contribute-table__cell">publisher</td>
                 <td class="contribute-table__cell">Publisher</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $b</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">DC terms:publisher</a>
+                    May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $b</a>, <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a>, or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">DC terms:publisher</a>.
                 </td>
             </tr>
             <tr>
@@ -147,12 +141,12 @@
                 <td class="contribute-table__cell">creator</td>
                 <td class="contribute-table__cell">Creator</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    Author, editor, creator, organisation - any named person/organisation involved in the creation of the work. May be in MARC <a href="https://www.loc.gov/marc/bibliographic/bd1xx.html">1xx</a>, <a href="https://www.loc.gov/marc/bibliographic/bd70x75x.html">7xx</a> and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/creator">DC terms:creator</a>, <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/contributor">DC terms:contributor</a>
+                    Author, editor, creator, organisation - any named person or organisation involved in the creation of the work. May be in MARC <a href="https://www.loc.gov/marc/bibliographic/bd1xx.html">1xx</a>, <a href="https://www.loc.gov/marc/bibliographic/bd70x75x.html">7xx</a> and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/creator">DC terms:creator</a>, <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/contributor">DC terms:contributor</a>.
                 </td>
             </tr>
             <tr>
@@ -160,12 +154,12 @@
                 <td class="contribute-table__cell">topic</td>
                 <td class="contribute-table__cell">Subject or topic</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>
+                    May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>.
                 </td>
             </tr>
             <tr>
@@ -173,12 +167,12 @@
                 <td class="contribute-table__cell">description</td>
                 <td class="contribute-table__cell">Description</td>
                 <td class="contribute-table__cell">Desireable</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    Description about the content. May be in <a href="https://www.loc.gov/marc/bibliographic/bd5xx.html">MARC 5xx</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/description">DC terms:description</a>
+                    Description about the content. May be in <a href="https://www.loc.gov/marc/bibliographic/bd5xx.html">MARC 5xx</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/description">DC terms:description</a>.
                 </td>
             </tr>
             <tr>
@@ -186,65 +180,41 @@
                 <td class="contribute-table__cell">urlPDF</td>
                 <td class="contribute-table__cell">URL of a PDF</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
-            </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
-                    If there is a PDF version of the item
-                </td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">12</th>
                 <td class="contribute-table__cell">urlIIIF</td>
                 <td class="contribute-table__cell">URL to a IIIF manifest</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
-            </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
-                    URL to a IIIF manifest
-                </td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">13</th>
                 <td class="contribute-table__cell">urlPlainText</td>
                 <td class="contribute-table__cell">URL to a plain text file</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
                 </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
-                    URL to a plain text file
-                </td>
-            </tr>
             <tr>
                 <th class="contribute-table__cell">14</th>
                 <td class="contribute-table__cell">urlALTOXML</td>
-                <td class="contribute-table__cell">URL to an ALTO XML file</td>
+                <td class="contribute-table__cell">URL to an <a href="https://en.wikipedia.org/wiki/ALTO_(XML)">ALTO XML</a> file</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
-            </tr>
-            <tr>
-                <td colspan="2" class="contribute-table__notes"></td>
-                <td colspan="3" class="contribute-table__notes">
-                    URL to an <a href="https://en.wikipedia.org/wiki/ALTO_(XML)">ALTO XML</a> file
-                </td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">15</th>
                 <td class="contribute-table__cell">urlOther</td>
-                <td class="contribute-table__cell">URL of other useful version(s)</td>
+                <td class="contribute-table__cell">Other URL(s)</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
                     If there are other URLs for the content that may be useful - perhaps 
-                    Google Books URL, or link to the catalogue record of the original
+                    Google Books URL, or link to the catalogue record of the original.
                 </td>
             </tr>
             <tr>
@@ -252,12 +222,12 @@
                 <td class="contribute-table__cell">placeOfPublication</td>
                 <td class="contribute-table__cell">Place of publication</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a>
+                May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a>.
                 </td>
             </tr>
             <tr>
@@ -265,55 +235,54 @@
                 <td class="contribute-table__cell">licence</td>
                 <td class="contribute-table__cell">Licence of the material</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd540.html">MARC 540</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">DC terms:rights</a><br/>
-                    <br/>
-                    For example CC-BY
+                    May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd540.html">MARC 540</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">DC terms:rights</a>. 
+                    For example CC-BY.
                 </td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">18</th>
                 <td class="contribute-table__cell">idOther</td>
-                <td class="contribute-table__cell">Other local or external ids</td>
+                <td class="contribute-table__cell">Other IDs</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">Yes</td>
+                <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    Other identifiers such as DOIs
+                    Other local or external identifiers such as DOIs.
                 </td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">19</th>
                 <td class="contribute-table__cell">catLink</td>
-                <td class="contribute-table__cell">A link directly to the item's catalogue record</td>
+                <td class="contribute-table__cell">Direct record link</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
-                    A link to the item in your catalogue or discovery system
+                    A link to the item in your catalogue or discovery system.
                 </td>
             </tr>
             <tr>
                 <th class="contribute-table__cell">20</th>
                 <td class="contribute-table__cell">language</td>
-                <td class="contribute-table__cell">language of the resource</td>
+                <td class="contribute-table__cell">Item language</td>
                 <td class="contribute-table__cell">Optional</td>
-                <td class="contribute-table__cell">No</td>
+                <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
                 <td colspan="2" class="contribute-table__notes"></td>
                 <td colspan="3" class="contribute-table__notes">
                     May be in MARC 008 position 35-37 and/or  MARC 041.<a href="https://www.loc.gov/marc/languages/">[code list]</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/language">DC terms:language</a>.
-                    Additional default values of 'Not specified' and 'Undetermined'
+                    Additional default values of 'Not specified' and 'Undetermined'.
                 </td>
             </tr>
         </tbody>

--- a/app/Views/contribute.php
+++ b/app/Views/contribute.php
@@ -33,7 +33,6 @@
     <table class="my-6 w-full md:my-12 md:table-auto md:w-auto md:-mx-24 md:max-w-screen lg:-mx-40 lg:max-w-screen-lg border">
         <thead>
             <tr>
-                <th scope="col" class="contribute-table__header">Column</th>
                 <th scope="col" class="contribute-table__header">Heading</th>
                 <th scope="col" class="contribute-table__header">Content</th>
                 <th scope="col" class="contribute-table__header">Requirement</th>
@@ -42,7 +41,6 @@
         </thead>
         <tbody>
             <tr>
-                <th scope="row" class="contribute-table__cell">1</th>
                 <td class="contribute-table__cell">organisation</td>
                 <td class="contribute-table__cell">Unique name of provider</td>
                 <td class="contribute-table__cell">Mandatory</td>
@@ -55,41 +53,38 @@
                 </td>
             </tr>
             <tr>
-                <th scope="row" class="contribute-table__cell">2</th>
                 <td class="contribute-table__cell">idLocal</td>
                 <td class="contribute-table__cell">Local identifier</td>
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     ID from the local system - so each library can look up their 
                     local system if there's a query. 
                 </td>
             </tr>
             <tr>
-                <th scope="row" class="contribute-table__cell">3</th>
                 <td class="contribute-table__cell">title</td>
                 <td class="contribute-table__cell">Title of the work</td>
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     For example <a href="https://www.loc.gov/marc/bibliographic/concise/bd245.html">MARC 245 $a $b</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/title">DC terms:title</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">4</th>
                 <td class="contribute-table__cell">urlMain</td>
                 <td class="contribute-table__cell">URL to access the item</td>
                 <td class="contribute-table__cell">Mandatory</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     The URL that is most appropriate for a user to follow to get direct/immediate access to the
                     content. May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd856.html">MARC 856</a> or 
@@ -97,188 +92,172 @@
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">5</th>
                 <td class="contribute-table__cell">year</td>
                 <td class="contribute-table__cell">Year of publication</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     This needs to be numeric and four digits in length as it is used to feed the year filter.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">6</th>
                 <td class="contribute-table__cell">date</td>
                 <td class="contribute-table__cell">Date of publication</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     Ideally numeric but can be any value. <a href="https://www.loc.gov/marc/bibliographic/concise/bd008a.html">MARC 008 position 7-10</a> rather than 
                     MARC 260 $c - e.g. preferred to 1884 vs ca.1884). May be in <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date">DC terms:date</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">7</th>
                 <td class="contribute-table__cell">publisher</td>
                 <td class="contribute-table__cell">Publisher</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $b</a>, <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a>, or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">DC terms:publisher</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">8</th>
                 <td class="contribute-table__cell">creator</td>
                 <td class="contribute-table__cell">Creator</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     Author, editor, creator, organisation - any named person or organisation involved in the creation of the work. May be in MARC <a href="https://www.loc.gov/marc/bibliographic/bd1xx.html">1xx</a>, <a href="https://www.loc.gov/marc/bibliographic/bd70x75x.html">7xx</a> and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/creator">DC terms:creator</a>, <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/contributor">DC terms:contributor</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">9</th>
                 <td class="contribute-table__cell">topic</td>
                 <td class="contribute-table__cell">Subject or topic</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/bd6xx.html">MARC 6xx</a>, and <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/subject">DC terms:subject</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">10</th>
                 <td class="contribute-table__cell">description</td>
                 <td class="contribute-table__cell">Description</td>
                 <td class="contribute-table__cell">Desireable</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     Description about the content. May be in <a href="https://www.loc.gov/marc/bibliographic/bd5xx.html">MARC 5xx</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/description">DC terms:description</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">11</th>
                 <td class="contribute-table__cell">urlPDF</td>
                 <td class="contribute-table__cell">URL of a PDF</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">12</th>
                 <td class="contribute-table__cell">urlIIIF</td>
                 <td class="contribute-table__cell">URL to a IIIF manifest</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">13</th>
                 <td class="contribute-table__cell">urlPlainText</td>
                 <td class="contribute-table__cell">URL to a plain text file</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
                 </tr>
             <tr>
-                <th class="contribute-table__cell">14</th>
                 <td class="contribute-table__cell">urlALTOXML</td>
                 <td class="contribute-table__cell">URL to an <a href="https://en.wikipedia.org/wiki/ALTO_(XML)">ALTO XML</a> file</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">15</th>
                 <td class="contribute-table__cell">urlOther</td>
                 <td class="contribute-table__cell">Other URL(s)</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     If there are other URLs for the content that may be useful - perhaps 
                     Google Books URL, or link to the catalogue record of the original.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">16</th>
                 <td class="contribute-table__cell">placeOfPublication</td>
                 <td class="contribute-table__cell">Place of publication</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                 May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd260.html">MARC 260 $a</a> or <a href="https://www.loc.gov/marc/bibliographic/bd264.html">MARC 264 $a</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/coverage">DC terms:coverage</a>.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">17</th>
                 <td class="contribute-table__cell">licence</td>
                 <td class="contribute-table__cell">Licence of the material</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     May be in <a href="https://www.loc.gov/marc/bibliographic/concise/bd540.html">MARC 540</a> or <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">DC terms:rights</a>. 
                     For example CC-BY.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">18</th>
                 <td class="contribute-table__cell">idOther</td>
                 <td class="contribute-table__cell">Other IDs</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     Other local or external identifiers such as DOIs.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">19</th>
                 <td class="contribute-table__cell">catLink</td>
                 <td class="contribute-table__cell">Direct record link</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     A link to the item in your catalogue or discovery system.
                 </td>
             </tr>
             <tr>
-                <th class="contribute-table__cell">20</th>
                 <td class="contribute-table__cell">language</td>
                 <td class="contribute-table__cell">Item language</td>
                 <td class="contribute-table__cell">Optional</td>
                 <td class="contribute-table__cell">Not repeatable</td>
             </tr>
             <tr class="contribute-table__notes">
-                <td colspan="2"></td>
+                <td colspan="1"></td>
                 <td colspan="3">
                     May be in MARC 008 position 35-37 and/or  MARC 041.<a href="https://www.loc.gov/marc/languages/">[code list]</a> or 
                     <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/language">DC terms:language</a>.

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -21,20 +21,20 @@ a:focus {
 }
 
 h1 {
-    @apply text-gray-700 text-2xl leading-tight mb-2;
+    @apply text-gray-700 text-3xl leading-tight mb-4;
 }
 
 h2 {
-    @apply text-gray-700 text-xl leading-tight mb-1 mt-8;
+    @apply text-gray-700 text-2xl leading-tight mb-4 mt-12;
 }
 
 p {
-    @apply mb-2;
+    @apply mb-4;
 }
 
 /* Use for intro paragraphs of text. */
 .intro {
-    @apply text-lg text-gray-700 text-opacity-75 mb-10;
+    @apply text-lg text-gray-700 text-opacity-75 mb-12 mt-6;
 }
 
 /* Navigation links */

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -3,7 +3,7 @@
 
 /* Main content container */
 .main-container {
-    @apply bg-white w-screen max-w-none py-16 px-4;
+    @apply bg-white w-screen max-w-none py-16 px-4 overflow-x-hidden;
 }
 
 /* Global text styles. */
@@ -279,11 +279,45 @@ body #doorbell #doorbell-powered-by {
 }
 
 .contribute-table__cell {
-    @apply border-t px-6 py-4 text-sm text-left text-gray-900;
+    @apply border-t px-6 py-4 text-sm text-left text-gray-900 font-normal;
 }
 
-.contribute-table__notes {
+.contribute-table__notes td {
     @apply px-6 pb-6 text-gray-600 text-sm;
+}
+
+@media only screen and (max-width: 767px) {
+	/* Force table to not be like tables anymore */
+	table, thead, tbody, th, td, tr { 
+		display: block; 
+	}
+	
+	.contribute-table__header { 
+		@apply sr-only;
+	}
+	
+	.contribute-table__cell { 
+        @apply pl-3 pt-4 pb-0 text-xs border-0 relative;
+		padding-left: 50%; 
+	}
+
+    .contribute-table__notes {
+        @apply border-b;
+    }
+
+    .contribute-table__notes td {
+        @apply px-3 pb-4 text-xs;
+    }
+	
+	.contribute-table__cell:before { 
+        @apply pl-3 pt-4 text-xs font-normal uppercase text-gray-700 tracking-wide whitespace-no-wrap absolute w-1/2 top-0 left-0;
+	}
+	
+    th.contribute-table__cell:nth-of-type(1):before { content: "Column"; }
+	td.contribute-table__cell:nth-of-type(1):before { content: "Heading"; }
+	.contribute-table__cell:nth-of-type(2):before { content: "Content"; }
+	.contribute-table__cell:nth-of-type(3):before { content: "Requirement"; }
+	.contribute-table__cell:nth-of-type(4):before { content: "Repeatable"; }
 }
 
 @tailwind utilities;

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -275,15 +275,15 @@ body #doorbell #doorbell-powered-by {
 
 /* Contribute table */
 .contribute-table__header {
-    @apply bg-gray-100 px-6 py-4 text-sm font-normal uppercase text-gray-700 tracking-wider text-left border-b;
+    @apply bg-gray-100 px-6 py-4 text-sm font-normal uppercase text-gray-700 tracking-wider text-left;
 }
 
 .contribute-table__cell {
-    @apply px-6 pt-4 pb-2 text-sm text-left text-gray-900;
+    @apply border-t px-6 py-4 text-sm text-left text-gray-900;
 }
 
 .contribute-table__notes {
-    @apply border-b px-6 pt-2 pb-6 text-gray-600 text-sm;
+    @apply px-6 pb-6 text-gray-600 text-sm;
 }
 
 @tailwind utilities;

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -273,4 +273,17 @@ body #doorbell #doorbell-powered-by {
     @apply block text-xs text-gray-600 text-center mt-8;
 }
 
+/* Contribute table */
+.contribute-table__header {
+    @apply bg-gray-100 px-6 py-4 text-sm font-normal uppercase text-gray-700 tracking-wider text-left border-b;
+}
+
+.contribute-table__cell {
+    @apply px-6 pt-4 pb-2 text-sm text-left text-gray-900;
+}
+
+.contribute-table__notes {
+    @apply border-b px-6 pt-2 pb-6 text-gray-600 text-sm;
+}
+
 @tailwind utilities;

--- a/app/styles/app.pcss
+++ b/app/styles/app.pcss
@@ -313,8 +313,7 @@ body #doorbell #doorbell-powered-by {
         @apply pl-3 pt-4 text-xs font-normal uppercase text-gray-700 tracking-wide whitespace-no-wrap absolute w-1/2 top-0 left-0;
 	}
 	
-    th.contribute-table__cell:nth-of-type(1):before { content: "Column"; }
-	td.contribute-table__cell:nth-of-type(1):before { content: "Heading"; }
+	.contribute-table__cell:nth-of-type(1):before { content: "Heading"; }
 	.contribute-table__cell:nth-of-type(2):before { content: "Content"; }
 	.contribute-table__cell:nth-of-type(3):before { content: "Requirement"; }
 	.contribute-table__cell:nth-of-type(4):before { content: "Repeatable"; }


### PR DESCRIPTION
Most of the work here was to format the table, which was a little hard to read and parse, especially on a mobile. I've reorganised things so it should be more straightforward to read now, as well as making a few very minor copyedits and removing notes entirely when it's just a duplicate of existing information.

Two small suggestions that might make it easy for libraries to share their data with us:
- Provide a sample CSV file for them to fill out (less likely) or reference (more likely).
- Instead of requiring _both_ position (column number) and name (column heading), would it make sense to just require a single one (ideally name)? This would simplify the table and allow libraries to focus on mapping the correct column name to the data, rather than having to worry about position as well.

Before:
![image](https://user-images.githubusercontent.com/376315/93718847-a3bce600-fb76-11ea-9826-f97f3ec07bcc.png)
<img src="https://user-images.githubusercontent.com/376315/93718855-ad464e00-fb76-11ea-9e4e-78fe9d195090.png" width="180" />


After:
![image](https://user-images.githubusercontent.com/376315/93718812-59d40000-fb76-11ea-9b6c-febc4da427fe.png)

<img src="https://user-images.githubusercontent.com/376315/93718827-76703800-fb76-11ea-869c-b2a666c32b60.png" width="180" />

Close #6 
