### PR TITLE
Fix hit highlighting

### DIFF
--- a/app/Controllers/Search.php
+++ b/app/Controllers/Search.php
@@ -58,7 +58,7 @@ class Search extends Controller
         
         // Only bring back the fields required
         $query->setFields(array('organisation', 'title', 'urlMain', 'creator', 'publisher', 'placeOfPublication', 'year', 
-                                'urlPDF', 'urlIIIF', 'urlPlainText', 'urlALTOXML', 'urlOther'));
+                                'urlPDF', 'urlIIIF', 'urlPlainText', 'urlALTOXML', 'urlOther', 'id'));
         
         // Generate the URL without pagination details
         $url = '/search/?q=' . $q;


### PR DESCRIPTION
The ID field was no longer being returned in the results (as an efficiency measure) but it is required as the key to find relevant highlighted fields.