### PR TITLE
Various fixes to searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ writable/uploads/*
 
 writable/debugbar/*
 
+/writable/query.log
+
 ~tm*
 
 php_errors.log

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -43,6 +43,13 @@
         <!-- Title -->
         <h2 class="text-darkCyan text-xl leading-tight mb-2">
             <a class="text-blue-700 hover:text-blue-600 inline-block" rel="bookmark"></a>
+            <?php
+            if($include_score) {
+                ?>
+                <span class="text-red-700"></span>
+            <?php
+            }
+            ?>
         </h2>
 
         <!-- Author -->

--- a/public/scripts/SearchResults/Models/query.js
+++ b/public/scripts/SearchResults/Models/query.js
@@ -102,7 +102,11 @@ export default class Query {
      * @returns {string}
      */
     buildDirectUrl() {
-        return `/search?${this._getQueryString()}`;
+        var url = `/search?${this._getQueryString()}`;
+        if(window.location.href.indexOf("debug_score") >= 0) {
+            url += "&debug_score";
+        }
+        return url;
     }
 
     /**
@@ -118,7 +122,11 @@ export default class Query {
      * @returns {string}
      */
     buildDataUrl() {
-        return `/search/data?${this._getQueryString()}`;
+        var url = `/search/data?${this._getQueryString()}`;
+        if(window.location.href.indexOf("debug_score") >= 0) {
+            url += "&debug_score";
+        }
+        return url;
     }
 
     /**

--- a/public/scripts/SearchResults/ViewControllers/result-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/result-view-controller.js
@@ -14,6 +14,9 @@ export default class ResultViewController {
             link.href = record.urlMain;
             addOutboundLinkHandler(index, link)
             this.SetInnerHTML(link, record.title);
+            if(record.score) {
+                link.nextElementSibling.innerText = `[${record.score}]`;
+            }
         }
         else
         {


### PR DESCRIPTION
Includes:
* Fix broken query after filtering
* Improve Fuzzy
* Add boolean switch for fuzzy
* Add debug options for showing score and seeing query transformations

I've left fuzzy search on but made it very easy to disable and improved the scoring following a bit of research - it now transforms as follows:
`dancing` -> `(dancing^2 OR dancing~)`
Making for more expected results:
![image](https://user-images.githubusercontent.com/188324/94464233-1c92f200-01b6-11eb-94a6-b05269d6b59d.png)

Also now in non-production environments a new file is written too at `/writable/query.log` simply showing the query transforms for debugging purposes and finally also in non-production environments if you append `&debug_score` to the URL the url for each result will also be displayed.
![image](https://user-images.githubusercontent.com/188324/94464427-5cf27000-01b6-11eb-80b1-09938891d635.png)
