### PR TITLE
Decode single quotes properly

### DIFF
--- a/app/Models/OTQuery.php
+++ b/app/Models/OTQuery.php
@@ -16,8 +16,7 @@ class OTQuery
 
     function __construct(string $q) {
 
-        $q = html_entity_decode($q);
-
+        $q = html_entity_decode($q, ENT_QUOTES | ENT_HTML5);
         $this->sanitisedQuery = $q;
 
         $q = urldecode($q);


### PR DESCRIPTION
For some reason PHP assumes you want to keep single quotes html encoded by default - have fixed this behavour. Could be seen in the midsummers night's dream suggested search.

![image](https://user-images.githubusercontent.com/188324/95015992-18e4ec80-0648-11eb-884f-58e9d888cefc.png)
