### PR TITLE
fix: a11y tweaks

### DIFF
--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -71,11 +71,11 @@
         <!-- Different formats for download -->
         <div class="flex flex-wrap items-baseline space-x-1 text-gray-600 text-sm">
             <span>Download:</span>
-            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>PDF</a>
-            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>IIIF</a>
-            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>Plain-text</span></a>
-            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as</span> ALTO XML</a>
-            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>Other format </a>
+            <a class="text-gray-600"><span class="sr-only">Download </span>PDF<span class="sr-only"> of {ARTICLE_TITLE}.</span></a>
+            <a class="text-gray-600"><span class="sr-only">Download </span>IIIF<span class="sr-only"> of {ARTICLE_TITLE}.</span></a>
+            <a class="text-gray-600"><span class="sr-only">Download </span>Plain-text<span class="sr-only"> of {ARTICLE_TITLE}.</span></a>
+            <a class="text-gray-600"><span class="sr-only">Download </span>ALTO XML<span class="sr-only"> of {ARTICLE_TITLE}.</span></a>
+            <a class="text-gray-600"><span class="sr-only">Download </span>Other format<span class="sr-only"> of {ARTICLE_TITLE}.</span></a>
         </div>
     </div>
 

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -71,11 +71,11 @@
         <!-- Different formats for download -->
         <div class="flex flex-wrap items-baseline space-x-1 text-gray-600 text-sm">
             <span>Download:</span>
-            <a class="text-gray-600">PDF</a>
-            <a class="text-gray-600">IIIF</a>
-            <a class="text-gray-600">Plain-text</a>
-            <a class="text-gray-600">ALTO XML</a>
-            <a class="text-gray-600">Other format</a>
+            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>PDF</a>
+            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>IIIF</a>
+            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>Plain-text</span></a>
+            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as</span> ALTO XML</a>
+            <a class="text-gray-600"><span class="sr-only">Download {ARTICLE TITLE} as </span>Other format </a>
         </div>
     </div>
 

--- a/app/Views/templates/site-footer.php
+++ b/app/Views/templates/site-footer.php
@@ -1,4 +1,4 @@
-        <footer role="footer" class="mx-auto max-w-3xl grid md:grid-cols-3 gap-x-24 gap-y-12 justify-center items-center p-6 md:p-12 text-white">
+        <footer role="contentinfo" class="mx-auto max-w-3xl grid md:grid-cols-3 gap-x-24 gap-y-12 justify-center items-center p-6 md:p-12 text-white">
             <?php
                 $uri = current_url(true);
                 $current_path = "/" . $uri->getSegment(1);

--- a/public/scripts/SearchResults/ViewControllers/result-view-controller.js
+++ b/public/scripts/SearchResults/ViewControllers/result-view-controller.js
@@ -53,9 +53,15 @@ export default class ResultViewController {
             iconStrip.parentNode.removeChild(iconStrip);
             return inflatedRecord;
         }
+        const basicTitle = (new DOMParser().parseFromString(record.title, 'text/html')).body.textContent || "";
+        const srText = ` of ${basicTitle}.`;
         for(let i = 0; i < urls.length; i++) {
             if (urls[i]) {
                 dlIcon.href = urls[i];
+                var srTextSpan = dlIcon.firstElementChild;
+                srTextSpan.innerText = "Download ";
+                srTextSpan = srTextSpan.nextElementSibling;
+                srTextSpan.innerText = srText;
                 addOutboundLinkHandler(index, dlIcon)
                 dlIcon.addEventListener('click', handleOutboundLink.bind(null, index))
                 dlIcon = dlIcon.nextElementSibling;
@@ -70,11 +76,13 @@ export default class ResultViewController {
 
                 if(i === 0) {
                     dlIcon.href = record.urlOther[i]
+                    dlIcon.firstElementChild.innerText = srText;
                     addOutboundLinkHandler(index, dlIcon)
                 } else {
                     const icon = dlIcon.cloneNode(true);
                     dlIcon.parentElement.appendChild(icon);
                     icon.href = record.urlOther[i]
+                    icon.firstElementChild.innerText = srText;
                     addOutboundLinkHandler(index, icon)
                 }
             }


### PR DESCRIPTION
This fixes two small issues:

- Site footer had the wrong ARIA role. I think this fell victim to a merge conflict resolution, probably by me!
- Adds descriptive text for screen readers for the format download links.

The latter will need article titles adding where {ARTICLE TITLE} currently is. @brizee, can I get your help with this? It's all Javascripty magic to me. 😉

Close #82.