### PR TITLE
feat: Introduce a darker shade for visited links.

### DIFF
--- a/app/Controllers/Search.php
+++ b/app/Controllers/Search.php
@@ -97,7 +97,7 @@ class Search extends Controller
 
         $hl = $query->getHighlighting();
         $hl->setFields('title, creator, year, publisher, placeOfPublication');
-        $hl->setSimplePrefix('<em class="text-current not-italic font-semibold">');
+        $hl->setSimplePrefix('<em class="not-italic font-semibold">');
         $hl->setSimplePostfix('</em>');
 
         // Execute the query and returns the result

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -47,7 +47,7 @@
 
         <!-- Title -->
         <h2 class="text-darkCyan text-xl leading-tight mb-2">
-            <a class="text-blue-700 hover:text-blue-600 inline-block" rel="bookmark"></a>
+            <a class="text-blue-700 hover:text-blue-600 visited:text-blue-800 inline-block" rel="bookmark"></a>
             <?php
             if($include_score) {
                 ?>

--- a/app/Views/templates/search-results.php
+++ b/app/Views/templates/search-results.php
@@ -47,7 +47,7 @@
 
         <!-- Title -->
         <h2 class="text-darkCyan text-xl leading-tight mb-2">
-            <a class="text-blue-700 hover:text-blue-600 visited:text-blue-800 inline-block" rel="bookmark"></a>
+            <a class="text-blue-700 hover:text-blue-600 visited:text-blue-800 visited inline-block" rel="bookmark"></a>
             <?php
             if($include_score) {
                 ?>

--- a/app/styles/base-styles.pcss
+++ b/app/styles/base-styles.pcss
@@ -46,6 +46,11 @@ p {
     @apply text-lg text-gray-600 mb-6 mt-6;
 }
 
+/* Brute-force visited links, since Tailwind isn't working properly. */
+.visited:visited {
+    @apply text-blue-800;
+}
+
 /* Extra classes to apply consistent sizing to icons. */
 .icon-sm svg {
     width: 16px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -90,4 +90,9 @@ module.exports = {
     './public/scripts/**/*.js'
   ]
   },
+  variants: {
+    extend: {
+      textColor: ['visited'],
+    }
+  },
 }


### PR DESCRIPTION
We're using a slightly darker shade of blue (in search results only) to help users distinguish the links they've already visited, without being too interruptive to the overall page design.

<img width="636" alt="Screenshot 2020-12-05 at 17 42 53" src="https://user-images.githubusercontent.com/376315/101259559-5b4aa880-3721-11eb-9d99-c57d22d53251.png">

Note: I wasn't able to test this locally, but I _think_ it should work smoothly!

Close #204.